### PR TITLE
Implement exercise list with toggle view

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/Exercise.kt
+++ b/app/src/main/java/com/example/gymapplktrack/Exercise.kt
@@ -1,0 +1,3 @@
+package com.example.gymapplktrack
+
+data class Exercise(val name: String, val record: String)

--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -3,9 +3,18 @@ package com.example.gymapplktrack
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.ViewList
+import androidx.compose.material.icons.filled.FitnessCenter
 import com.example.gymapplktrack.ui.theme.GymTrackTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -14,7 +23,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -69,7 +81,41 @@ enum class Screen { Exercises, Routines, Profile }
 
 @Composable
 fun ExercisesScreen() {
-    Text(text = stringResource(id = R.string.exercises))
+    var gridMode by remember { mutableStateOf(false) }
+
+    val exercises = remember {
+        List(100) { index ->
+            Exercise(name = "Exercise ${index + 1}", record = "X")
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            IconButton(onClick = { gridMode = !gridMode }) {
+                val icon: ImageVector = if (gridMode) Icons.Default.ViewList else Icons.Default.GridView
+                Icon(imageVector = icon, contentDescription = null)
+            }
+        }
+
+        if (gridMode) {
+            LazyVerticalGrid(columns = GridCells.Fixed(2), modifier = Modifier.fillMaxSize()) {
+                items(exercises) { exercise ->
+                    ExerciseItem(exercise, grid = true)
+                }
+            }
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(exercises) { exercise ->
+                    ExerciseItem(exercise)
+                }
+            }
+        }
+    }
 }
 
 @Composable
@@ -80,4 +126,48 @@ fun RoutinesScreen() {
 @Composable
 fun ProfileScreen() {
     Text(text = stringResource(id = R.string.profile))
+}
+
+@Composable
+fun ExerciseItem(exercise: Exercise, grid: Boolean = false) {
+    val modifier = if (grid) {
+        Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+    } else {
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    }
+    if (grid) {
+        Column(
+            modifier = modifier,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Default.FitnessCenter,
+                contentDescription = null,
+                modifier = Modifier.size(80.dp)
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = exercise.name, fontWeight = FontWeight.Bold)
+            Text(text = "Record: ${exercise.record}")
+        }
+    } else {
+        Row(
+            modifier = modifier,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.FitnessCenter,
+                contentDescription = null,
+                modifier = Modifier.size(40.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Column {
+                Text(text = exercise.name, fontWeight = FontWeight.Bold)
+                Text(text = "Record: ${exercise.record}")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement simple Exercise data model
- add big exercise list with toggle between list and grid views
- show exercise name in bold and placeholder record value

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684349d39734832cbb679a20a5f17121