### PR TITLE
Improve dark theme and reposition view toggle

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.ViewList
 import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.List
 import com.example.gymapplktrack.ui.theme.GymTrackTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,7 +34,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            GymTrackTheme {
+            GymTrackTheme(darkTheme = true) {
                 GymTrackApp()
             }
         }
@@ -50,19 +52,34 @@ fun GymTrackApp() {
                     selected = selectedScreen == Screen.Exercises,
                     onClick = { selectedScreen = Screen.Exercises },
                     label = { Text(stringResource(id = R.string.exercises)) },
-                    icon = {}
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Default.FitnessCenter,
+                            contentDescription = null
+                        )
+                    }
                 )
                 NavigationBarItem(
                     selected = selectedScreen == Screen.Routines,
                     onClick = { selectedScreen = Screen.Routines },
                     label = { Text(stringResource(id = R.string.routines)) },
-                    icon = {}
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Default.List,
+                            contentDescription = null
+                        )
+                    }
                 )
                 NavigationBarItem(
                     selected = selectedScreen == Screen.Profile,
                     onClick = { selectedScreen = Screen.Profile },
                     label = { Text(stringResource(id = R.string.profile)) },
-                    icon = {}
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Default.Person,
+                            contentDescription = null
+                        )
+                    }
                 )
             }
         }
@@ -89,19 +106,7 @@ fun ExercisesScreen() {
         }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.End
-        ) {
-            IconButton(onClick = { gridMode = !gridMode }) {
-                val icon: ImageVector = if (gridMode) Icons.Default.ViewList else Icons.Default.GridView
-                Icon(imageVector = icon, contentDescription = null)
-            }
-        }
-
+    Box(modifier = Modifier.fillMaxSize()) {
         if (gridMode) {
             LazyVerticalGrid(columns = GridCells.Fixed(2), modifier = Modifier.fillMaxSize()) {
                 items(exercises) { exercise ->
@@ -114,6 +119,16 @@ fun ExercisesScreen() {
                     ExerciseItem(exercise)
                 }
             }
+        }
+
+        FloatingActionButton(
+            onClick = { gridMode = !gridMode },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+        ) {
+            val icon: ImageVector = if (gridMode) Icons.Default.ViewList else Icons.Default.GridView
+            Icon(imageVector = icon, contentDescription = null)
         }
     }
 }

--- a/app/src/main/java/com/example/gymapplktrack/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/theme/Theme.kt
@@ -3,10 +3,21 @@ package com.example.gymapplktrack.ui.theme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.Composable
 
 private val LightColors = lightColorScheme()
-private val DarkColors = darkColorScheme()
+
+private val DarkColors = darkColorScheme(
+    primary = Color(0xFFD32F2F),
+    secondary = Color(0xFFF44336),
+    background = Color(0xFF121212),
+    surface = Color(0xFF1E1E1E),
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onBackground = Color.White,
+    onSurface = Color.White
+)
 
 @Composable
 fun GymTrackTheme(


### PR DESCRIPTION
## Summary
- customize Material3 dark theme colors for a gym feel
- default to dark theme in the app
- add icons to bottom navigation items
- move view mode button to a floating action button at bottom right

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434c1b1d64832c9508c332cc62cf9a