### PR TITLE
Fix layout padding for exercises list

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.example.gymapplktrack
 
 import android.os.Bundle
+import android.graphics.Color
+import androidx.core.view.WindowCompat
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
@@ -29,10 +31,13 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.statusBarsPadding
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.BLACK
         setContent {
             GymTrackTheme(darkTheme = true) {
                 GymTrackApp()
@@ -84,7 +89,13 @@ fun GymTrackApp() {
             }
         }
     ) { padding ->
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .statusBarsPadding(),
+            contentAlignment = Alignment.Center
+        ) {
             when (selectedScreen) {
                 Screen.Exercises -> ExercisesScreen()
                 Screen.Routines -> RoutinesScreen()


### PR DESCRIPTION
## Summary
- avoid overlap with system bars by applying `statusBarsPadding()` and Scaffold padding
- set decor fits system windows and status bar color

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434e049c10832cbfbc0d84d6b96f71