### PR TITLE
Add persistent exercises and image preview

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.runtime)
     implementation(libs.coil.compose)
+    implementation(libs.gson)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/gymapplktrack/ExerciseRepository.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ExerciseRepository.kt
@@ -1,0 +1,30 @@
+package com.example.gymapplktrack
+
+import android.content.Context
+import android.net.Uri
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+class ExerciseRepository(context: Context) {
+    private val prefs = context.getSharedPreferences("exercises", Context.MODE_PRIVATE)
+    private val gson = Gson()
+
+    fun loadExercises(): MutableList<Exercise> {
+        val json = prefs.getString("list", null)
+        return if (json != null) {
+            val type = object : TypeToken<List<ExerciseDto>>() {}.type
+            val dtos: List<ExerciseDto> = gson.fromJson(json, type)
+            dtos.map { Exercise(it.name, it.record, it.imageUri?.let { uri -> Uri.parse(uri) }) }.toMutableList()
+        } else {
+            mutableListOf()
+        }
+    }
+
+    fun saveExercises(exercises: List<Exercise>) {
+        val dtos = exercises.map { ExerciseDto(it.name, it.record, it.imageUri?.toString()) }
+        prefs.edit().putString("list", gson.toJson(dtos)).apply()
+    }
+
+    private data class ExerciseDto(val name: String, val record: String, val imageUri: String?)
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ espressoCore = "3.6.1"
 appcompat = "1.7.0"
 material = "1.12.0"
 coil = "2.7.0"
+gson = "2.10.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -25,6 +26,7 @@ compose-foundation = { group = "androidx.compose.foundation", name = "foundation
 compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "compose" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- persist exercises in `ExerciseRepository` using SharedPreferences and Gson
- display preview image in exercise creation dialog
- load saved exercises at startup
- add Gson dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684353f1965c832c884e6437bf6a0bec