### PR TITLE
Fix experimental foundation API usage in ExerciseItem

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import coil.compose.AsyncImage
 import android.net.Uri
@@ -273,6 +274,7 @@ fun ProfileScreen() {
     Text(text = stringResource(id = R.string.profile))
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ExerciseItem(
     exercise: Exercise,


### PR DESCRIPTION
## Summary
- import `ExperimentalFoundationApi`
- mark `ExerciseItem` with `@OptIn(ExperimentalFoundationApi::class)`

## Testing
- `./gradlew assembleDebug --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843930461dc832c98637dfe76a5d3b3