### PR TITLE
Fix unresolved reference to background

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.background
 import coil.compose.AsyncImage
 import android.net.Uri
 import android.content.Intent


### PR DESCRIPTION
## Summary
- import `androidx.compose.foundation.background`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439444fb0c832c9424784dd398ccbb