### PR TITLE
Implement record tracking

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/Exercise.kt
+++ b/app/src/main/java/com/example/gymapplktrack/Exercise.kt
@@ -2,8 +2,14 @@ package com.example.gymapplktrack
 
 import android.net.Uri
 
+data class ExerciseRecord(
+    val weight: Int,
+    val reps: Int,
+    val date: String
+)
+
 data class Exercise(
     val name: String,
-    val record: String,
+    val records: MutableList<ExerciseRecord> = mutableListOf(),
     val imageUri: Uri? = null
 )

--- a/app/src/main/java/com/example/gymapplktrack/ExerciseRepository.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ExerciseRepository.kt
@@ -14,17 +14,30 @@ class ExerciseRepository(context: Context) {
         return if (json != null) {
             val type = object : TypeToken<List<ExerciseDto>>() {}.type
             val dtos: List<ExerciseDto> = gson.fromJson(json, type)
-            dtos.map { Exercise(it.name, it.record, it.imageUri?.let { uri -> Uri.parse(uri) }) }.toMutableList()
+            dtos.map { dto ->
+                Exercise(
+                    dto.name,
+                    dto.records.map { ExerciseRecord(it.weight, it.reps, it.date) }.toMutableList(),
+                    dto.imageUri?.let { uri -> Uri.parse(uri) }
+                )
+            }.toMutableList()
         } else {
             mutableListOf()
         }
     }
 
     fun saveExercises(exercises: List<Exercise>) {
-        val dtos = exercises.map { ExerciseDto(it.name, it.record, it.imageUri?.toString()) }
+        val dtos = exercises.map { ex ->
+            ExerciseDto(
+                ex.name,
+                ex.records.map { ExerciseRecordDto(it.weight, it.reps, it.date) },
+                ex.imageUri?.toString()
+            )
+        }
         prefs.edit().putString("list", gson.toJson(dtos)).apply()
     }
 
-    private data class ExerciseDto(val name: String, val record: String, val imageUri: String?)
+    private data class ExerciseRecordDto(val weight: Int, val reps: Int, val date: String)
+    private data class ExerciseDto(val name: String, val records: List<ExerciseRecordDto>, val imageUri: String?)
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,11 @@
     <string name="select_photo">Seleccionar foto</string>
     <string name="delete">Eliminar</string>
     <string name="delete_exercises_question">\u00BFDeseas eliminar %1$d ejercicios?</string>
+    <string name="place_record">Colocar Record</string>
+    <string name="weight">Peso</string>
+    <string name="reps">Repeticiones</string>
+    <string name="date">Fecha</string>
+    <string name="save">Guardar</string>
+    <string name="record_history">Historial</string>
+    <string name="delete_record_question">\u00BFDeseas eliminar este record?</string>
 </resources>


### PR DESCRIPTION
## Summary
- allow multiple records for exercises
- show record info only if a record exists
- add detail screen to view and manage exercise records
- persist exercise records in repository
- provide strings for record management dialog

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684397656a28832c89b29aa48daea476