### PR TITLE
Fix experimental API warning

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -529,7 +529,7 @@ fun AddRecordDialog(onDismiss: () -> Unit, onSave: (Int, Int, String) -> Unit) {
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ExerciseDetailScreen(
     exercise: Exercise,


### PR DESCRIPTION
## Summary
- add ExperimentalFoundationApi opt-in to `ExerciseDetailScreen`

## Testing
- `./gradlew build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439b12e9f0832c8ff10a5b8b6f9c6e