### PR TITLE
Handle invalid stored exercise data

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ExerciseRepository.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ExerciseRepository.kt
@@ -10,8 +10,8 @@ class ExerciseRepository(context: Context) {
     private val gson = Gson()
 
     fun loadExercises(): MutableList<Exercise> {
-        val json = prefs.getString("list", null)
-        return if (json != null) {
+        val json = prefs.getString("list", null) ?: return mutableListOf()
+        return try {
             val type = object : TypeToken<List<ExerciseDto>>() {}.type
             val dtos: List<ExerciseDto> = gson.fromJson(json, type)
             dtos.map { dto ->
@@ -21,7 +21,7 @@ class ExerciseRepository(context: Context) {
                     dto.imageUri?.let { uri -> Uri.parse(uri) }
                 )
             }.toMutableList()
-        } else {
+        } catch (_: Exception) {
             mutableListOf()
         }
     }


### PR DESCRIPTION
## Summary
- handle corrupt JSON when loading stored exercises

## Testing
- `./gradlew test --warning-mode all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439c88799c832c8bdd6d6bf5aaf0bd