### PR TITLE
Fix AddRecordDialog experimental Material3 call

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -491,6 +491,7 @@ fun AddExerciseDialog(onDismiss: () -> Unit, onAdd: (String, Uri?) -> Unit) {
 }
 
 @Composable
+@OptIn(ExperimentalMaterial3Api::class)
 fun AddRecordDialog(onDismiss: () -> Unit, onSave: (Int, Int, String) -> Unit) {
     var weight by remember { mutableStateOf("") }
     var reps by remember { mutableStateOf("") }


### PR DESCRIPTION
## Summary
- opt-in to Material3 experimental API in `AddRecordDialog`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_6843a008c4d0832c8f6bb20d4384046a