### PR TITLE
Add weight progression chart

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import com.example.gymapplktrack.ui.theme.GymTrackTheme
+import com.example.gymapplktrack.WeightProgressChart
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -636,6 +637,9 @@ fun ExerciseDetailScreen(
                         }
                     }
                 }
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(text = stringResource(id = R.string.weight_progression), fontWeight = FontWeight.Bold)
+                WeightProgressChart(exercise.records, modifier = Modifier.padding(top = 8.dp))
             }
         }
     }

--- a/app/src/main/java/com/example/gymapplktrack/WeightChart.kt
+++ b/app/src/main/java/com/example/gymapplktrack/WeightChart.kt
@@ -1,0 +1,74 @@
+package com.example.gymapplktrack
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.weight
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.text.style.TextAlign
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun WeightProgressChart(records: List<ExerciseRecord>, modifier: Modifier = Modifier) {
+    if (records.isEmpty()) return
+
+    val formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+    val sorted = records.sortedBy { LocalDate.parse(it.date, formatter) }
+    val maxWeight = sorted.maxOf { it.weight }.coerceAtLeast(1)
+
+    Column(modifier = modifier) {
+        androidx.compose.foundation.Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(150.dp)
+        ) {
+            val stepX = if (sorted.size > 1) size.width / (sorted.size - 1) else size.width
+            val height = size.height
+            val scaleY = height / maxWeight
+
+            val path = Path()
+            sorted.forEachIndexed { index, rec ->
+                val x = stepX * index
+                val y = height - rec.weight * scaleY
+                if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+            }
+            drawPath(
+                path = path,
+                color = MaterialTheme.colorScheme.primary,
+                style = Stroke(width = 4.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round)
+            )
+            sorted.forEachIndexed { index, rec ->
+                val x = stepX * index
+                val y = height - rec.weight * scaleY
+                drawCircle(
+                    color = MaterialTheme.colorScheme.primary,
+                    radius = 4.dp.toPx(),
+                    center = Offset(x, y)
+                )
+            }
+        }
+        Row(modifier = Modifier.fillMaxWidth()) {
+            sorted.forEach { rec ->
+                Text(
+                    text = rec.date,
+                    fontSize = 10.sp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,5 +17,6 @@
     <string name="date">Fecha</string>
     <string name="save">Guardar</string>
     <string name="record_history">Historial</string>
+    <string name="weight_progression">Evoluci\u00f3n del peso</string>
     <string name="delete_record_question">\u00BFDeseas eliminar este record?</string>
 </resources>


### PR DESCRIPTION
## Summary
- show a weight progress chart on the exercise detail screen
- add WeightProgressChart composable
- add a new string for the header

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a23674f8832c8de7e58fd0fc14ee