### PR TITLE
Fix weight import

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/WeightChart.kt
+++ b/app/src/main/java/com/example/gymapplktrack/WeightChart.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
## Summary
- drop internal weight import from WeightChart.kt

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a39ab014832ca58672cde13d615e