### PR TITLE
Add routines management

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/Routine.kt
+++ b/app/src/main/java/com/example/gymapplktrack/Routine.kt
@@ -1,0 +1,10 @@
+package com.example.gymapplktrack
+
+/**
+ * Represents a workout routine with a name and the list of exercise names
+ * that belong to it.
+ */
+data class Routine(
+    val name: String,
+    val exercises: MutableList<String> = mutableListOf()
+)

--- a/app/src/main/java/com/example/gymapplktrack/RoutineRepository.kt
+++ b/app/src/main/java/com/example/gymapplktrack/RoutineRepository.kt
@@ -1,0 +1,31 @@
+package com.example.gymapplktrack
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+/**
+ * Simple persistence helper that stores routines in SharedPreferences using JSON.
+ */
+class RoutineRepository(context: Context) {
+    private val prefs = context.getSharedPreferences("routines", Context.MODE_PRIVATE)
+    private val gson = Gson()
+
+    fun loadRoutines(): MutableList<Routine> {
+        val json = prefs.getString("list", null) ?: return mutableListOf()
+        return try {
+            val type = object : TypeToken<List<RoutineDto>>() {}.type
+            val dtos: List<RoutineDto> = gson.fromJson(json, type)
+            dtos.map { Routine(it.name, it.exercises.toMutableList()) }.toMutableList()
+        } catch (_: Exception) {
+            mutableListOf()
+        }
+    }
+
+    fun saveRoutines(routines: List<Routine>) {
+        val dtos = routines.map { RoutineDto(it.name, it.exercises) }
+        prefs.edit().putString("list", gson.toJson(dtos)).apply()
+    }
+
+    private data class RoutineDto(val name: String, val exercises: List<String>)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,10 @@
     <string name="record_history">Historial</string>
     <string name="weight_progression">Evoluci\u00f3n del peso</string>
     <string name="delete_record_question">\u00BFDeseas eliminar este record?</string>
+    <string name="create_routine">+ Crear Rutina</string>
+    <string name="routine_name">Nombre de la Rutina</string>
+    <string name="delete_routines_question">\u00BFDeseas eliminar %1$d rutinas?</string>
+    <string name="add_to_routine">Agregar ejercicio</string>
+    <string name="delete_from_routine_question">\u00BFDeseas eliminar este ejercicio de la rutina?</string>
+    <string name="no_exercises_available">No hay ejercicios disponibles</string>
 </resources>


### PR DESCRIPTION
## Summary
- create Routine data class and persistence via RoutineRepository
- keep the exercise list empty initially
- implement routine CRUD screens using Compose
- allow adding exercises to routines and viewing routine detail
- translate new UI strings for routines

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a75641a0832cbe9b3f622dbe077e