### PR TITLE
Annotate RoutineDetailScreen for experimental API

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -465,6 +465,7 @@ fun AddRoutineDialog(onDismiss: () -> Unit, onAdd: (String) -> Unit) {
 }
 
 @Composable
+@OptIn(ExperimentalMaterial3Api::class)
 fun RoutineDetailScreen(
     routine: Routine,
     exercises: List<Exercise>,


### PR DESCRIPTION
## Summary
- opt in to ExperimentalMaterial3Api for RoutineDetailScreen to silence build error

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a92413ac832c985437570260c94f