### PR TITLE
Fix Compose Color import

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
+++ b/app/src/main/java/com/example/gymapplktrack/MainActivity.kt
@@ -1,7 +1,8 @@
 package com.example.gymapplktrack
 
 import android.os.Bundle
-import android.graphics.Color
+import android.graphics.Color as AndroidColor
+import androidx.compose.ui.graphics.Color
 import androidx.core.view.WindowCompat
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -63,7 +64,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.statusBarColor = Color.BLACK
+        window.statusBarColor = AndroidColor.BLACK
         val repository = ExerciseRepository(this)
         val routineRepository = RoutineRepository(this)
         setContent {


### PR DESCRIPTION
## Summary
- import Compose `Color` in `MainActivity`
- alias Android's `Color` to avoid name clash

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843aa359ed8832ca272fa509b652c21