### PR TITLE
Fix missing padding import in GymTrackApp

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/GymTrackApp.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/GymTrackApp.kt
@@ -1,6 +1,7 @@
 package com.example.gymapplktrack.ui
 
 import android.content.Intent
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.FitnessCenter


### PR DESCRIPTION
## Summary
- import the Compose padding modifier so the Scaffold content lambda compiles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6739a7188832cb551f89bcc3ad4b6