### PR TITLE
Fix ensure workout log reference in profile view model

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/profile/ProfileViewModel.kt
@@ -82,7 +82,7 @@ class ProfileViewModel(
         }
     }
 
-    fun ensureLog(date: LocalDate) {
+    fun ensureWorkoutLog(date: LocalDate) {
         viewModelScope.launch { repository.ensureWorkoutLog(date) }
     }
 


### PR DESCRIPTION
## Summary
- rename the ProfileViewModel helper to ensureWorkoutLog so it matches the call site in GymTrackApp

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f674366f64832cbd849621a01516c0