### PR TITLE
Fix SavedStateHandle factory imports

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/exercises/ExerciseDetailViewModel.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/exercises/ExerciseDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.createSavedStateHandle
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.gymapplktrack.AppContainer
 import com.example.gymapplktrack.data.repository.GymRepository

--- a/app/src/main/java/com/example/gymapplktrack/ui/features/routines/RoutineEditorViewModel.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/routines/RoutineEditorViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.createSavedStateHandle
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.gymapplktrack.AppContainer
 import com.example.gymapplktrack.data.repository.GymRepository


### PR DESCRIPTION
## Summary
- replace the old lifecycle.viewmodel.createSavedStateHandle import with lifecycle.createSavedStateHandle in the view model factories
- keep ExerciseDetailViewModel and RoutineEditorViewModel using the CreationExtras helper so saved state arguments resolve correctly

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f677c7b5b8832c913b739c043a968c