### PR TITLE
Fix missing rememberCoroutineScope import in exercises screen

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/exercises/ExercisesScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/exercises/ExercisesScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip


### PR DESCRIPTION
## Summary
- add the missing `rememberCoroutineScope` import so the exercises screen compiles again

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f679075688832c933577fb34928770