### PR TITLE
Add missing Compose text dependency for keyboard options

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.lifecycle.viewmodel.savedstate)
     implementation(libs.activity.compose)
     implementation(libs.compose.ui)
+    implementation(libs.compose.ui.text)
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)
     implementation(libs.material)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+compose-ui-text = { group = "androidx.compose.ui", name = "ui-text" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
## Summary
- add the Compose UI text artifact to the version catalog
- depend on the new Compose text library so KeyboardOptions resolves

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f67b3c2a70832cbe7b94ddbd011844