### PR TITLE
Fix WorkoutScreen KeyboardOptions import

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.example.gymapplktrack.domain.model.ExerciseOverview


### PR DESCRIPTION
## Summary
- correct the KeyboardOptions import used by WorkoutScreen's input fields to resolve build errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f67c5e6698832ca396d4c26a61e0d3