### PR TITLE
Revamp GymTrack UI with aggressive dark theme

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = "11"
@@ -67,6 +68,7 @@ dependencies {
     implementation(libs.navigation.compose)
     implementation(libs.coil.compose)
     implementation(libs.gson)
+    coreLibraryDesugaring(libs.desugarJdkLibs)
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     kapt(libs.room.compiler)

--- a/app/src/main/java/com/example/gymapplktrack/ui/features/exercises/ExercisesScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/exercises/ExercisesScreen.kt
@@ -83,9 +83,14 @@ fun ExercisesScreen(
     }
 
     Scaffold(
+        containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
-            FloatingActionButton(onClick = onAddExercise, containerColor = MaterialTheme.colorScheme.primary) {
+            FloatingActionButton(
+                onClick = onAddExercise,
+                containerColor = MaterialTheme.colorScheme.secondary,
+                contentColor = MaterialTheme.colorScheme.onSecondary
+            ) {
                 Icon(Icons.Default.Add, contentDescription = "Agregar ejercicio")
             }
         }
@@ -97,9 +102,9 @@ fun ExercisesScreen(
                 .padding(16.dp)
         ) {
             Text(
-                text = "Ejercicios",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
+                text = "Explota tus ejercicios",
+                style = MaterialTheme.typography.displaySmall,
+                fontWeight = FontWeight.Black
             )
             Spacer(modifier = Modifier.height(12.dp))
             OutlinedTextField(
@@ -199,15 +204,16 @@ private fun CategoryFilter(categories: List<String>, selected: String?, onChange
 private fun ExerciseListItem(exercise: ExerciseOverview, onClick: () -> Unit, onDelete: () -> Unit) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        shape = RoundedCornerShape(18.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         onClick = onClick
     ) {
         Row(modifier = Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
             ExerciseImage(imageUri = exercise.imageUri)
             Spacer(modifier = Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
-                Text(text = exercise.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(text = exercise.name.uppercase(), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
                 exercise.personalRecord?.let { record ->
                     Text(
                         text = "Record: ${record.bestWeightKg} kg × ${record.bestReps}",
@@ -220,7 +226,7 @@ private fun ExerciseListItem(exercise: ExerciseOverview, onClick: () -> Unit, on
                     color = MaterialTheme.colorScheme.primary
                 )
             }
-            TextButton(onClick = onDelete) { Text("Eliminar") }
+            TextButton(onClick = onDelete) { Text("Eliminar", color = MaterialTheme.colorScheme.secondary) }
         }
     }
 }

--- a/app/src/main/java/com/example/gymapplktrack/ui/features/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/profile/ProfileScreen.kt
@@ -9,29 +9,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.gymapplktrack.domain.model.DailyLog
 import com.example.gymapplktrack.ui.components.MonthCalendar
@@ -48,12 +37,17 @@ fun ProfileScreen(
     onOpenPreferences: () -> Unit
 ) {
     Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
         topBar = {
             TopAppBar(
-                title = { Text("Perfil") },
+                title = { Text("Perfil", style = MaterialTheme.typography.titleLarge) },
                 actions = {
                     TextButton(onClick = onOpenPreferences) { Text("Preferencias") }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
             )
         }
     ) { padding ->
@@ -65,8 +59,12 @@ fun ProfileScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             item {
-                Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
-                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Surface(
+                    tonalElevation = 6.dp,
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)
+                ) {
+                    Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         Text("Calendario de entrenos", style = MaterialTheme.typography.titleMedium)
                         Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
                             TextButton(onClick = onPreviousMonth) { Text("Anterior") }
@@ -76,16 +74,18 @@ fun ProfileScreen(
                         MonthCalendar(
                             month = state.month,
                             highlightedDays = state.workoutMarkedDays,
-                            onDayClick = {
-                                onEnsureLog(it)
-                            }
+                            onDayClick = onEnsureLog
                         )
                     }
                 }
             }
             item {
-                Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
-                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Surface(
+                    tonalElevation = 6.dp,
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)
+                ) {
+                    Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text("Creatina", style = MaterialTheme.typography.titleMedium)
                         state.logs.forEach { log ->
                             CreatineRow(log = log, onToggle = onToggleCreatine)
@@ -94,16 +94,24 @@ fun ProfileScreen(
                 }
             }
             item {
-                Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
-                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Surface(
+                    tonalElevation = 6.dp,
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)
+                ) {
+                    Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text("Racha actual", style = MaterialTheme.typography.titleMedium)
                         Text("${state.streakInfo?.currentStreak ?: 0} ${state.streakInfo?.mode?.name?.lowercase()} consecutivos")
                     }
                 }
             }
             item {
-                Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
-                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Surface(
+                    tonalElevation = 6.dp,
+                    modifier = Modifier.fillMaxWidth(),
+                    color = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)
+                ) {
+                    Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text("Estadísticas", style = MaterialTheme.typography.titleMedium)
                         Text("Sesiones este mes: ${state.summary?.monthlySessions ?: 0}")
                         Text("Ejercicios más frecuentes: ${state.summary?.topExercises?.joinToString().orEmpty()}")

--- a/app/src/main/java/com/example/gymapplktrack/ui/features/routines/RoutineEditorScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/routines/RoutineEditorScreen.kt
@@ -2,6 +2,8 @@ package com.example.gymapplktrack.ui.features.routines
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,42 +14,72 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.Divider
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.gymapplktrack.domain.model.ExerciseOverview
+import kotlinx.coroutines.flow.Flow
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RoutineEditorScreen(
     state: RoutineEditorUiState,
+    events: Flow<RoutineEditorEvent>,
     onBack: () -> Unit,
     onNameChange: (String) -> Unit,
     onAddExercise: (Long) -> Unit,
     onRemoveExercise: (Long) -> Unit,
     onMoveExercise: (Int, Int) -> Unit,
-    onSave: () -> Unit
+    onSave: () -> Unit,
+    onSaved: (Long) -> Unit
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(events) {
+        events.collect { event ->
+            when (event) {
+                is RoutineEditorEvent.Error -> snackbarHostState.showSnackbar(event.message)
+                is RoutineEditorEvent.Saved -> onSaved(event.routineId)
+            }
+        }
+    }
+
     Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                title = { Text("Editar rutina") },
+                title = { Text("Diseñar rutina", style = MaterialTheme.typography.titleLarge) },
                 navigationIcon = {
                     IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = "Volver") }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
             )
         }
     ) { padding ->
@@ -56,50 +88,124 @@ fun RoutineEditorScreen(
                 .fillMaxSize()
                 .padding(padding)
                 .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            OutlinedTextField(
-                value = state.name,
-                onValueChange = onNameChange,
+            Card(
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Nombre de la rutina") }
-            )
-            Text("Selecciona ejercicios", style = MaterialTheme.typography.titleMedium)
-            ExerciseSelector(
-                available = state.available,
-                selectedIds = state.selected.map { it.id }.toSet(),
-                onToggle = { exerciseId, selected ->
-                    if (selected) onAddExercise(exerciseId) else onRemoveExercise(exerciseId)
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+            ) {
+                Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("Nombre del plan", style = MaterialTheme.typography.titleMedium)
+                    OutlinedTextField(
+                        value = state.name,
+                        onValueChange = onNameChange,
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text("Hazlo intimidante") }
+                    )
                 }
-            )
+            }
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+            ) {
+                Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("Arsenal disponible", style = MaterialTheme.typography.titleMedium)
+                    ExerciseSelector(
+                        available = state.available,
+                        selectedIds = state.selected.map { it.id }.toSet(),
+                        onToggle = { exerciseId, isSelected ->
+                            if (isSelected) onAddExercise(exerciseId) else onRemoveExercise(exerciseId)
+                        }
+                    )
+                }
+            }
             if (state.selected.isNotEmpty()) {
-                Text("Orden actual", fontWeight = FontWeight.SemiBold)
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    items(state.selected, key = { it.id }) { item ->
-                        Text("${item.order + 1}. ${item.name}")
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+                ) {
+                    Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Text("Orden de ataque", style = MaterialTheme.typography.titleMedium)
+                        LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                            items(state.selected, key = { it.id }) { item ->
+                                val canMoveUp = item.order > 0
+                                val canMoveDown = item.order < state.selected.lastIndex
+                                RoutineOrderRow(
+                                    item = item,
+                                    canMoveUp = canMoveUp,
+                                    canMoveDown = canMoveDown,
+                                    onMoveUp = { onMoveExercise(item.order, (item.order - 1).coerceAtLeast(0)) },
+                                    onMoveDown = { onMoveExercise(item.order, (item.order + 1).coerceAtMost(state.selected.lastIndex)) },
+                                    onRemove = { onRemoveExercise(item.id) }
+                                )
+                            }
+                        }
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(12.dp))
-            Button(onClick = onSave, modifier = Modifier.fillMaxWidth()) { Text("Guardar rutina") }
+            Spacer(modifier = Modifier.height(8.dp))
+            Button(onClick = onSave, modifier = Modifier.fillMaxWidth()) {
+                Text("Guardar rutina")
+            }
         }
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ExerciseSelector(
     available: List<ExerciseOverview>,
     selectedIds: Set<Long>,
     onToggle: (Long, Boolean) -> Unit
 ) {
-    LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        items(available, key = { it.id }) { exercise ->
-            val checked = selectedIds.contains(exercise.id)
-            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                Checkbox(checked = checked, onCheckedChange = { onToggle(exercise.id, it) })
-                Text(exercise.name)
+    if (available.isEmpty()) {
+        Text("Agrega ejercicios desde la pestaña principal", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        return
+    }
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        available.forEach { exercise ->
+            val selected = selectedIds.contains(exercise.id)
+            AssistChip(
+                onClick = { onToggle(exercise.id, !selected) },
+                label = { Text(exercise.name.uppercase()) },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = if (selected) MaterialTheme.colorScheme.secondary.copy(alpha = 0.2f)
+                    else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.7f),
+                    labelColor = MaterialTheme.colorScheme.onSurface
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun RoutineOrderRow(
+    item: RoutineExerciseDraft,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onRemove: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text("${item.order + 1}. ${item.name}", style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.SemiBold)
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onMoveUp, enabled = canMoveUp) {
+                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "Subir")
             }
-            Divider()
+            IconButton(onClick = onMoveDown, enabled = canMoveDown) {
+                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "Bajar")
+            }
+            TextButton(onClick = onRemove) { Text("Quitar") }
         }
     }
 }

--- a/app/src/main/java/com/example/gymapplktrack/ui/features/routines/RoutinesScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/routines/RoutinesScreen.kt
@@ -13,15 +13,16 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.FlashOn
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,16 +45,26 @@ fun RoutinesScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+            .padding(horizontal = 16.dp, vertical = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
-        Text("Rutinas", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+        Text("Tus rituales", style = MaterialTheme.typography.displaySmall)
         if (workoutState.workout != null) {
-            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Surface(
+                tonalElevation = 8.dp,
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)
+            ) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                     Text("Entreno en progreso", style = MaterialTheme.typography.titleMedium)
-                    Text("Ejercicios activos: ${workoutState.workout.exercises.size}")
-                    Button(onClick = onResumeWorkout) { Text("Continuar") }
+                    Text(
+                        "Ejercicios activos: ${workoutState.workout.exercises.size}",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Button(onClick = onResumeWorkout) { Text("Retomar intensidad") }
                 }
             }
         }
@@ -64,15 +75,15 @@ fun RoutinesScreen(
                 Button(onClick = onCreateRoutine) {
                     Icon(Icons.Default.Add, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text("Crear rutina")
+                    Text("Nueva rutina")
                 }
                 OutlinedButton(onClick = onStartFree) {
-                    Icon(Icons.Default.PlayArrow, contentDescription = null)
+                    Icon(Icons.Default.FlashOn, contentDescription = null)
                     Spacer(modifier = Modifier.width(8.dp))
                     Text("Entreno libre")
                 }
             }
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 items(state.routines, key = { it.id }) { routine ->
                     RoutineCard(
                         routine = routine,
@@ -90,15 +101,20 @@ fun RoutinesScreen(
 private fun RoutineCard(routine: RoutineOverview, onStart: () -> Unit, onEdit: () -> Unit, onDelete: () -> Unit) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
     ) {
-        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(routine.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-            Text("${routine.exercises.size} ejercicios")
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Button(onClick = onStart) { Text("Iniciar") }
+        Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text(routine.name.uppercase(), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            Text(
+                "${routine.exercises.size} ejercicios asignados",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(onClick = onStart) { Text("Ejecutar") }
                 OutlinedButton(onClick = onEdit) { Text("Editar") }
-                OutlinedButton(onClick = onDelete) { Text("Eliminar") }
+                TextButton(onClick = onDelete) { Text("Borrar") }
             }
         }
     }
@@ -113,9 +129,9 @@ private fun EmptyRoutineState(onCreateRoutine: () -> Unit, onStartFree: () -> Un
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text("No tienes rutinas aún", style = MaterialTheme.typography.titleMedium)
+        Text("Sin rituales todavía", style = MaterialTheme.typography.titleMedium)
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = onCreateRoutine) { Text("Crear rutina") }
+        Button(onClick = onCreateRoutine) { Text("Crear tu primera rutina") }
         Spacer(modifier = Modifier.height(8.dp))
         OutlinedButton(onClick = onStartFree) { Text("Entreno libre") }
     }

--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -1,8 +1,10 @@
 package com.example.gymapplktrack.ui.features.workout
 
-import androidx.compose.foundation.border
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,9 +13,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -23,9 +33,11 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -35,16 +47,15 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.example.gymapplktrack.domain.model.ExerciseOverview
 import com.example.gymapplktrack.domain.model.WorkoutExercise
-import com.example.gymapplktrack.domain.model.WorkoutSummary
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun WorkoutScreen(
     state: WorkoutUiState,
@@ -53,7 +64,7 @@ fun WorkoutScreen(
     onAddExercise: (Long) -> Unit,
     onRemoveExercise: (Long) -> Unit,
     onAddSet: (Long, Float, Int) -> Unit,
-    onRemoveSet: (Long) -> Unit,
+    onRemoveSet: (Long, Int) -> Unit,
     onFinish: () -> Unit,
     onDiscard: () -> Unit,
     onNotesChange: (String) -> Unit,
@@ -65,44 +76,54 @@ fun WorkoutScreen(
             when (event) {
                 is WorkoutEvent.Error -> snackbarHostState.showSnackbar(event.message)
                 is WorkoutEvent.Completed -> onShowSummary()
+                is WorkoutEvent.RoutineSaved -> snackbarHostState.showSnackbar("Rutina \"${event.name}\" guardada")
             }
         }
     }
 
     Scaffold(
+        containerColor = Color.Transparent,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                title = { Text("Entreno activo") },
+                title = { Text("Entreno activo", style = MaterialTheme.typography.titleLarge) },
                 navigationIcon = {
-                    IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = "Volver") }
-                }
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Volver")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
             )
-        },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        }
     ) { padding ->
         if (state.workout == null) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .padding(32.dp),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text("Selecciona una rutina para comenzar")
-                Spacer(modifier = Modifier.height(12.dp))
-                Button(onClick = onDiscard) { Text("Volver") }
-            }
+            EmptyWorkoutState(modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+                onDiscard = onDiscard
+            )
         } else {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)
-                    .padding(16.dp),
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                AddExerciseSection(available = state.availableExercises, workout = state.workout, onAddExercise = onAddExercise)
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.weight(1f)) {
+                ActiveWorkoutHeader(state)
+                AddExerciseSection(
+                    available = state.availableExercises,
+                    workout = state.workout,
+                    onAddExercise = onAddExercise
+                )
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(14.dp),
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(bottom = 32.dp)
+                ) {
                     items(state.workout.exercises, key = { it.exerciseId }) { exercise ->
                         WorkoutExerciseCard(
                             exercise = exercise,
@@ -116,17 +137,79 @@ fun WorkoutScreen(
                     value = state.notes,
                     onValueChange = onNotesChange,
                     modifier = Modifier.fillMaxWidth(),
+                    textStyle = MaterialTheme.typography.bodyLarge,
                     label = { Text("Notas del entreno") }
                 )
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-                    OutlinedButton(onClick = onDiscard, modifier = Modifier.weight(1f)) { Text("Descartar") }
-                    Button(onClick = onFinish, modifier = Modifier.weight(1f)) { Text("Terminar") }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedButton(
+                        onClick = onDiscard,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Descartar") }
+                    Button(
+                        onClick = onFinish,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Terminar") }
                 }
             }
         }
     }
 }
 
+@Composable
+private fun EmptyWorkoutState(modifier: Modifier = Modifier, onDiscard: () -> Unit) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Sin entreno activo",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            "Vuelve a la pantalla de rutinas para iniciar un nuevo entreno.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.height(18.dp))
+        Button(onClick = onDiscard) {
+            Text("Volver")
+        }
+    }
+}
+
+@Composable
+private fun ActiveWorkoutHeader(state: WorkoutUiState) {
+    Surface(
+        tonalElevation = 6.dp,
+        shape = RoundedCornerShape(18.dp),
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f)
+    ) {
+        Column(
+            modifier = Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text("INTENSIDAD", style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.secondary)
+            Text(
+                text = if (state.workout?.routineId == null) "Entreno libre" else "${state.workout.exercises.size} ejercicios preparados",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = "Series registradas: ${state.workout?.exercises?.sumOf { it.sets.size } ?: 0}",
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AddExerciseSection(
     available: List<ExerciseOverview>,
@@ -135,13 +218,28 @@ private fun AddExerciseSection(
 ) {
     val availableToAdd = available.filterNot { exercise -> workout.exercises.any { it.exerciseId == exercise.id } }
     if (availableToAdd.isEmpty()) return
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text("Agregar ejercicio", style = MaterialTheme.typography.titleMedium)
-        LazyColumn(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.height(120.dp)) {
-            items(availableToAdd, key = { it.id }) { exercise ->
-                OutlinedButton(onClick = { onAddExercise(exercise.id) }, modifier = Modifier.fillMaxWidth()) {
-                    Text(exercise.name)
-                }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text(
+            text = "Agregar potencia",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            availableToAdd.forEach { exercise ->
+                AssistChip(
+                    onClick = { onAddExercise(exercise.id) },
+                    label = { Text(exercise.name.uppercase()) },
+                    leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
+                    colors = AssistChipDefaults.assistChipColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.75f),
+                        labelColor = MaterialTheme.colorScheme.onSurface,
+                        leadingIconContentColor = MaterialTheme.colorScheme.secondary
+                    )
+                )
             }
         }
     }
@@ -151,57 +249,106 @@ private fun AddExerciseSection(
 private fun WorkoutExerciseCard(
     exercise: WorkoutExercise,
     onAddSet: (Long, Float, Int) -> Unit,
-    onRemoveSet: (Long) -> Unit,
+    onRemoveSet: (Long, Int) -> Unit,
     onRemoveExercise: (Long) -> Unit
 ) {
     var weightInput by rememberSaveable(exercise.exerciseId, "weight") { mutableStateOf("") }
     var repsInput by rememberSaveable(exercise.exerciseId, "reps") { mutableStateOf("") }
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(12.dp)
-            .border(1.dp, MaterialTheme.colorScheme.outline, MaterialTheme.shapes.medium)
-            .padding(12.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(18.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
-            Text(exercise.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-            TextButton(onClick = { onRemoveExercise(exercise.exerciseId) }) { Text("Quitar") }
-        }
-        if (exercise.sets.isEmpty()) {
-            Text("Sin series aún", style = MaterialTheme.typography.bodySmall)
-        } else {
-            exercise.sets.forEachIndexed { index, set ->
-                Text("Serie ${index + 1}: ${set.weightKg} kg × ${set.reps}")
-            }
-        }
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
-            OutlinedTextField(
-                value = weightInput,
-                onValueChange = { weightInput = it },
-                modifier = Modifier.weight(1f),
-                label = { Text("Peso (kg)") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-            )
-            OutlinedTextField(
-                value = repsInput,
-                onValueChange = { repsInput = it },
-                modifier = Modifier.weight(1f),
-                label = { Text("Reps") },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
-            )
-        }
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = {
-                val weight = weightInput.toFloatOrNull()
-                val reps = repsInput.toIntOrNull()
-                if (weight != null && reps != null) {
-                    onAddSet(exercise.exerciseId, weight, reps)
-                    weightInput = ""
-                    repsInput = ""
+        Column(
+            modifier = Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column {
+                    Text(exercise.name.uppercase(), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                    Text(
+                        text = "${exercise.sets.size} series acumuladas",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
-            }) { Text("Agregar serie") }
-            OutlinedButton(onClick = { onRemoveSet(exercise.exerciseId) }) { Text("Eliminar última") }
+                TextButton(onClick = { onRemoveExercise(exercise.exerciseId) }) {
+                    Text("Quitar")
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                if (exercise.sets.isEmpty()) {
+                    Text("Aún sin series. Empieza a cargar peso.", style = MaterialTheme.typography.bodyMedium)
+                } else {
+                    exercise.sets.forEachIndexed { index, set ->
+                        Surface(
+                            tonalElevation = 2.dp,
+                            shape = RoundedCornerShape(12.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateItemPlacement()
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Column {
+                                    Text("Serie ${index + 1}", style = MaterialTheme.typography.labelLarge)
+                                    Text("${set.weightKg} kg  ×  ${set.reps} reps", style = MaterialTheme.typography.bodyMedium)
+                                }
+                                IconButton(onClick = { onRemoveSet(exercise.exerciseId, index) }) {
+                                    Icon(Icons.Default.Close, contentDescription = "Eliminar serie")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = weightInput,
+                    onValueChange = { weightInput = it },
+                    modifier = Modifier.weight(1f),
+                    label = { Text("Peso (kg)") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                )
+                OutlinedTextField(
+                    value = repsInput,
+                    onValueChange = { repsInput = it },
+                    modifier = Modifier.weight(1f),
+                    label = { Text("Reps") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(onClick = {
+                    val weight = weightInput.toFloatOrNull()
+                    val reps = repsInput.toIntOrNull()
+                    if (weight != null && reps != null) {
+                        onAddSet(exercise.exerciseId, weight, reps)
+                        weightInput = ""
+                        repsInput = ""
+                    }
+                }) {
+                    Text("Agregar serie")
+                }
+                OutlinedButton(onClick = { onRemoveExercise(exercise.exerciseId) }) {
+                    Text("Eliminar ejercicio")
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutSummaryScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutSummaryScreen.kt
@@ -2,6 +2,7 @@ package com.example.gymapplktrack.ui.features.workout
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,31 +10,102 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.gymapplktrack.domain.model.WorkoutSummary
+import kotlinx.coroutines.flow.Flow
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WorkoutSummaryScreen(state: WorkoutUiState, onBack: () -> Unit, onShare: (WorkoutSummary) -> Unit) {
+fun WorkoutSummaryScreen(
+    state: WorkoutUiState,
+    events: Flow<WorkoutEvent>,
+    onBack: () -> Unit,
+    onShare: (WorkoutSummary) -> Unit,
+    onSaveRoutine: (String) -> Unit
+) {
     val summary = state.lastSummary
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showSaveDialog by remember { mutableStateOf(false) }
+    var routineName by rememberSaveable { mutableStateOf("") }
+
+    LaunchedEffect(events) {
+        events.collect { event ->
+            when (event) {
+                is WorkoutEvent.RoutineSaved -> {
+                    snackbarHostState.showSnackbar("Rutina \"${event.name}\" guardada")
+                    showSaveDialog = false
+                    routineName = ""
+                }
+                is WorkoutEvent.Error -> snackbarHostState.showSnackbar(event.message)
+                else -> Unit
+            }
+        }
+    }
+
+    if (showSaveDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                showSaveDialog = false
+            },
+            confirmButton = {
+                Button(onClick = { onSaveRoutine(routineName) }) {
+                    Text("Guardar")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showSaveDialog = false }) {
+                    Text("Cancelar")
+                }
+            },
+            title = { Text("Nombrar rutina") },
+            text = {
+                OutlinedTextField(
+                    value = routineName,
+                    onValueChange = { routineName = it },
+                    label = { Text("Nombre del entreno") }
+                )
+            }
+        )
+    }
+
     Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
-                title = { Text("Entreno completado") },
+                title = { Text("Entreno completado", style = MaterialTheme.typography.titleLarge) },
                 navigationIcon = {
                     IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = "Volver") }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+                    titleContentColor = MaterialTheme.colorScheme.onSurface
+                )
             )
         }
     ) { padding ->
@@ -41,33 +113,91 @@ fun WorkoutSummaryScreen(state: WorkoutUiState, onBack: () -> Unit, onShare: (Wo
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp)
         ) {
             if (summary == null) {
                 Text("No hay resumen disponible", style = MaterialTheme.typography.titleMedium)
             } else {
-                Text("¡Buen trabajo!", style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
-                Text("Duración: ${summary.duration.toMinutes()} minutos")
-                Text("Ejercicios: ${summary.totalExercises}")
-                Text("Series totales: ${summary.totalSets}")
-                Spacer(modifier = Modifier.height(12.dp))
-                if (summary.brokenRecords.isNotEmpty()) {
-                    Text("Récords alcanzados", fontWeight = FontWeight.SemiBold)
-                    summary.brokenRecords.forEach { record ->
-                        Text("${record.exerciseName}: ${record.weightKg} kg × ${record.reps}")
+                Surface(
+                    tonalElevation = 8.dp,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(20.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text("¡Victoria lograda!", style = MaterialTheme.typography.displaySmall)
+                        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                            SummaryStat(label = "Duración", value = "${summary.duration.toMinutes()} min")
+                            SummaryStat(label = "Ejercicios", value = summary.totalExercises.toString())
+                            SummaryStat(label = "Series", value = summary.totalSets.toString())
+                        }
+                        if (summary.brokenRecords.isNotEmpty()) {
+                            Text("Récords batidos", style = MaterialTheme.typography.titleMedium)
+                            summary.brokenRecords.forEach { record ->
+                                Text(
+                                    text = "${record.exerciseName}: ${record.weightKg} kg × ${record.reps}",
+                                    style = MaterialTheme.typography.bodyLarge
+                                )
+                            }
+                        } else {
+                            Text(
+                                text = "Sin nuevos récords esta vez, pero el esfuerzo cuenta.",
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                        }
                     }
-                } else {
-                    Text("Sin nuevos récords esta vez", fontWeight = FontWeight.SemiBold)
                 }
-                Spacer(modifier = Modifier.height(16.dp))
+                if (state.canSaveCompletedWorkout) {
+                    Surface(
+                        tonalElevation = 4.dp,
+                        modifier = Modifier.fillMaxWidth(),
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.9f)
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(20.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Text(
+                                "¿Deseas guardar este entreno?",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            Text(
+                                "Se convertirá en una nueva rutina con el orden de ejercicios que acabas de completar.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                                Button(onClick = { showSaveDialog = true }) {
+                                    Text("Guardar como rutina")
+                                }
+                                TextButton(onClick = { showSaveDialog = false }) {
+                                    Text("No guardar")
+                                }
+                            }
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
                 Button(onClick = { onShare(summary) }, modifier = Modifier.fillMaxWidth()) {
                     Text("Compartir resumen")
                 }
-                Button(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(onClick = onBack, modifier = Modifier.fillMaxWidth()) {
                     Text("Volver")
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SummaryStat(label: String, value: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(text = label.uppercase(), style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.secondary)
+        Text(text = value, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
     }
 }

--- a/app/src/main/java/com/example/gymapplktrack/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/theme/Color.kt
@@ -2,13 +2,14 @@ package com.example.gymapplktrack.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val PrimaryLight = Color(0xFF4CAF50)
-val PrimaryDark = Color(0xFF81C784)
-val SecondaryLight = Color(0xFFFFC107)
-val SecondaryDark = Color(0xFFFFB300)
-val BackgroundLight = Color(0xFFF7F8FA)
-val BackgroundDark = Color(0xFF101418)
-val SurfaceLight = Color(0xFFFFFFFF)
-val SurfaceDark = Color(0xFF1C1F24)
-val OnPrimaryLight = Color.White
-val OnPrimaryDark = Color(0xFF0F1B0E)
+val InkBlack = Color(0xFF050505)
+val Carbon = Color(0xFF121212)
+val ForgedSteel = Color(0xFF1F1F1F)
+val Gunmetal = Color(0xFF2B2B2B)
+val SmokeGray = Color(0xFF3C3C3C)
+val FrostWhite = Color(0xFFF8F8F8)
+val GhostWhite = Color(0xFFE6E6E6)
+val BattleScarlet = Color(0xFFFF2741)
+val ElectricAccent = Color(0xFF62F5FF)
+val ShadowTint = Color(0xFF151515)
+val OutlineGray = Color(0xFF404040)

--- a/app/src/main/java/com/example/gymapplktrack/ui/theme/Decorations.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/theme/Decorations.kt
@@ -1,0 +1,37 @@
+package com.example.gymapplktrack.ui.theme
+
+import androidx.compose.foundation.background
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.TileMode
+
+@Composable
+fun Modifier.gymGradientBackground(): Modifier {
+    val colors = MaterialTheme.colorScheme
+    val gradient = remember(colors) {
+        Brush.verticalGradient(
+            colors = listOf(
+                colors.background,
+                colors.surface,
+                colors.background
+            ),
+            tileMode = TileMode.Clamp
+        )
+    }
+    return this.background(gradient)
+}
+
+@Composable
+fun Modifier.gymCardBackground(): Modifier {
+    val colors = MaterialTheme.colorScheme
+    val gradient = remember(colors) {
+        Brush.linearGradient(
+            colors = listOf(colors.surface, colors.surfaceVariant.copy(alpha = 0.9f)),
+            tileMode = TileMode.Clamp
+        )
+    }
+    return this.background(gradient)
+}

--- a/app/src/main/java/com/example/gymapplktrack/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/theme/Theme.kt
@@ -1,56 +1,70 @@
 package com.example.gymapplktrack.ui.theme
 
 import android.app.Activity
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 private val LightColors = lightColorScheme(
-    primary = PrimaryLight,
-    onPrimary = OnPrimaryLight,
-    secondary = SecondaryLight,
-    background = BackgroundLight,
-    surface = SurfaceLight
+    primary = InkBlack,
+    onPrimary = FrostWhite,
+    primaryContainer = InkBlack,
+    onPrimaryContainer = FrostWhite,
+    secondary = BattleScarlet,
+    onSecondary = FrostWhite,
+    secondaryContainer = Gunmetal,
+    onSecondaryContainer = FrostWhite,
+    tertiary = ElectricAccent,
+    onTertiary = InkBlack,
+    background = FrostWhite,
+    surface = GhostWhite,
+    surfaceVariant = GhostWhite,
+    onSurface = InkBlack,
+    onSurfaceVariant = InkBlack.copy(alpha = 0.7f),
+    outline = OutlineGray
 )
 
 private val DarkColors = darkColorScheme(
-    primary = PrimaryDark,
-    onPrimary = OnPrimaryDark,
-    secondary = SecondaryDark,
-    background = BackgroundDark,
-    surface = SurfaceDark
+    primary = FrostWhite,
+    onPrimary = InkBlack,
+    primaryContainer = BattleScarlet,
+    onPrimaryContainer = FrostWhite,
+    secondary = BattleScarlet,
+    onSecondary = FrostWhite,
+    secondaryContainer = ShadowTint,
+    onSecondaryContainer = FrostWhite,
+    tertiary = ElectricAccent,
+    onTertiary = InkBlack,
+    background = InkBlack,
+    surface = Carbon,
+    surfaceVariant = ForgedSteel,
+    onSurface = GhostWhite,
+    onSurfaceVariant = GhostWhite.copy(alpha = 0.7f),
+    outline = OutlineGray
 )
 
 @Composable
 fun GymTrackTheme(
     useDarkTheme: Boolean = isSystemInDarkTheme(),
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (useDarkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-        useDarkTheme -> DarkColors
-        else -> LightColors
-    }
+    val colorScheme = if (useDarkTheme) DarkColors else LightColors
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
             window.statusBarColor = colorScheme.background.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !useDarkTheme
+            window.navigationBarColor = colorScheme.background.toArgb()
+            val controller = WindowCompat.getInsetsController(window, view)
+            controller.isAppearanceLightStatusBars = !useDarkTheme
+            controller.isAppearanceLightNavigationBars = !useDarkTheme
         }
     }
     MaterialTheme(

--- a/app/src/main/java/com/example/gymapplktrack/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/theme/Type.kt
@@ -6,20 +6,43 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
+private val aggressiveFamily = FontFamily.SansSerif
+
 val Typography = Typography(
+    displaySmall = TextStyle(
+        fontFamily = aggressiveFamily,
+        fontWeight = FontWeight.Black,
+        letterSpacing = 1.2.sp,
+        fontSize = 32.sp
+    ),
     titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = aggressiveFamily,
         fontWeight = FontWeight.Bold,
+        letterSpacing = 0.8.sp,
         fontSize = 24.sp
     ),
+    titleMedium = TextStyle(
+        fontFamily = aggressiveFamily,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = 0.4.sp,
+        fontSize = 18.sp
+    ),
     bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
+        fontFamily = aggressiveFamily,
         fontWeight = FontWeight.Normal,
-        fontSize = 16.sp
+        fontSize = 16.sp,
+        letterSpacing = 0.2.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = aggressiveFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        letterSpacing = 0.2.sp
     ),
     labelLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.SemiBold,
-        fontSize = 14.sp
+        fontFamily = aggressiveFamily,
+        fontWeight = FontWeight.Medium,
+        fontSize = 13.sp,
+        letterSpacing = 0.4.sp
     )
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ datastore-preferences = { group = "androidx.datastore", name = "datastore-prefer
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
+desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version = "2.1.3" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTest" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
## Summary
- adopt the new monochrome palette, typography, and gradient surfaces across navigation, exercises, routines, and profile screens for an aggressive dark look
- overhaul the workout flow with per-set removal, shareable summaries, and the option to save free sessions as named routines
- harden the routine editor UX and enable core library desugaring to keep the profile tab stable on pre-26 devices

## Testing
- `./gradlew test` *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f67f4bc154832c9ef783c725c22553