### PR TITLE
Fix workout summary share intent formatting

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/GymTrackApp.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/GymTrackApp.kt
@@ -254,9 +254,10 @@ fun GymTrackApp() {
                             navController.popBackStack(BottomDestination.Routines.route, inclusive = false)
                         },
                         onShare = { summary ->
+                            val shareText = "Entreno completado: ${summary.totalExercises} ejercicios, ${summary.totalSets} series"
                             val shareIntent = Intent(Intent.ACTION_SEND).apply {
                                 type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, "Entreno completado: ${summary.totalExercises} ejercicios, ${summary.totalSets} series")
+                                putExtra(Intent.EXTRA_TEXT, shareText)
                             }
                             context.startActivity(Intent.createChooser(shareIntent, "Compartir resumen"))
                         },


### PR DESCRIPTION
## Summary
- ensure the workout summary share text is constructed without spanning multiple lines inside the template
- reuse the generated share text when configuring the share intent

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f68436e89c832ca4fa5414156b58b2