### PR TITLE
Fix experimental layout opt-in

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -1,8 +1,8 @@
 package com.example.gymapplktrack.ui.features.workout
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -55,7 +55,7 @@ import com.example.gymapplktrack.domain.model.ExerciseOverview
 import com.example.gymapplktrack.domain.model.WorkoutExercise
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WorkoutScreen(
     state: WorkoutUiState,
@@ -209,7 +209,7 @@ private fun ActiveWorkoutHeader(state: WorkoutUiState) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun AddExerciseSection(
     available: List<ExerciseOverview>,


### PR DESCRIPTION
## Summary
- replace the deprecated ExperimentalFoundation opt-in with ExperimentalLayout for the FlowRow usage in `WorkoutScreen`
- clean up the related imports

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f6884d59ec832c8108c21910f919b7