### PR TITLE
Fix missing opt-in for animateItemPlacement

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -1,5 +1,6 @@
 package com.example.gymapplktrack.ui.features.workout
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -245,6 +246,7 @@ private fun AddExerciseSection(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun WorkoutExerciseCard(
     exercise: WorkoutExercise,


### PR DESCRIPTION
## Summary
- opt into ExperimentalFoundationApi where animateItemPlacement is used to fix the unresolved reference
- import ExperimentalFoundationApi in WorkoutScreen

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: requires local Android SDK configuration in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6894bd754832c895f1fdda1a473d9