### PR TITLE
Fix missing opt-in for animateItemPlacement usage

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -247,6 +247,7 @@ private fun AddExerciseSection(
 }
 
 @OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun WorkoutExerciseCard(
     exercise: WorkoutExercise,


### PR DESCRIPTION
## Summary
- opt in to ExperimentalFoundationApi in WorkoutExerciseCard so animateItemPlacement resolves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f68a596100832cabc41d1232462a54