### PR TITLE
Fix duplicate ExperimentalFoundation OptIn annotation

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -247,7 +247,6 @@ private fun AddExerciseSection(
 }
 
 @OptIn(ExperimentalFoundationApi::class)
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun WorkoutExerciseCard(
     exercise: WorkoutExercise,


### PR DESCRIPTION
## Summary
- remove the duplicate ExperimentalFoundationApi opt-in annotation on WorkoutExerciseCard to resolve compiler error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f68b48aa94832cbbc81dd12d1675af