### PR TITLE
Fix missing animateItemPlacement import

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons


### PR DESCRIPTION
## Summary
- add the compose foundation lazy animateItemPlacement import so the modifier extension resolves

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f68cae60a0832c8428fe395fcc54d4