### PR TITLE
Fix animateItemPlacement import for workout screen

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.animateItemPlacement
+import androidx.compose.foundation.lazy.layout.animateItemPlacement
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons


### PR DESCRIPTION
## Summary
- update the workout screen to use the new animateItemPlacement import from the lazy layout package

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f68d9feacc832ca5b423837d5af30c