### PR TITLE
Fix workout set animation modifier

### DIFF
--- a/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/gymapplktrack/ui/features/workout/WorkoutScreen.kt
@@ -1,5 +1,6 @@
 package com.example.gymapplktrack.ui.features.workout
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,7 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -296,7 +296,7 @@ private fun WorkoutExerciseCard(
                             color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f),
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .animateItemPlacement()
+                                .animateContentSize()
                         ) {
                             Row(
                                 modifier = Modifier


### PR DESCRIPTION
## Summary
- replace the unavailable animateItemPlacement modifier with animateContentSize
- add the necessary animation import for the workout screen

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f68f7c8720832c92516da198052e7b